### PR TITLE
ZoneNameValidator - allow "localhost." as domain

### DIFF
--- a/src/conftest.py
+++ b/src/conftest.py
@@ -175,7 +175,7 @@ def mock_pdns_get_zones(mocker):
     rval = [
         'example.com.',
         'example.org.',
-    ] + [f'example{i}.org' for i in range(500)]
+    ] + [f'example{i}.org' for i in range(500)] + ['localhost.']
     return mocker.patch('dino.pdns_api.pdns.get_zones', return_value=rval)
 
 

--- a/src/dino/zoneeditor/views.py
+++ b/src/dino/zoneeditor/views.py
@@ -78,7 +78,7 @@ class ZoneNameValidator(RegexValidator):
     hostname_re = r'[_a-z' + URLValidator.ul + r'0-9](?:[a-z' + URLValidator.ul + r'0-9-]{0,61}[a-z' + URLValidator.ul + r'0-9])?'
     # identical to URLValidator.domain_re, except for leading underscroes
     domain_re = r'(?:\.(?!-)[_a-z' + URLValidator.ul + r'0-9-]{1,63}(?<!-))*'
-    unanchored_regex = fr'{hostname_re}{domain_re}{URLValidator.tld_re}'
+    unanchored_regex = fr'({hostname_re}{domain_re}{URLValidator.tld_re}|{URLValidator.tld_re[1:]})'
     regex = fr'^{unanchored_regex}\Z'
 
 


### PR DESCRIPTION
index by 1 skips the leading dot

    tld_re = (
        r"\."  # dot

https://github.com/django/django/blob/ae509f8f0804dea0eea89e27329014616c9d4cc0/django/core/validators.py#L85